### PR TITLE
Added local Kubernetes cluster setup and ingress deployment

### DIFF
--- a/deployment/kind-ingress/README.md
+++ b/deployment/kind-ingress/README.md
@@ -1,0 +1,81 @@
+# APISIX Ingress using Kind
+Setup a minimal local kubernetes cluster using [kind](https://kind.sigs.k8s.io/) and deploy the APISIX ingress controller. 
+
+This is a slight variation to https://apisix.apache.org/docs/ingress-controller/deployments/kind/ 
+
+## Prerequisites
+- Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
+- Install [Helm](https://helm.sh/)
+- Install [kubectl](https://kubernetes.io/docs/tasks/tools/)
+
+### Commands
+
+### Setup local Kubernetes cluster
+To create a local kind cluster named `apisix-ingress` with a portmapping rule forwarding port 80 of the host to `nodeport` 30965 
+```shell
+kind create cluster --name apisix-ingress --config=kind-cluster-config.yaml
+```
+
+### Install Helm repo's
+```shell
+helm repo add apisix https://charts.apiseven.com
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+```
+
+### Install APISIX Ingress via Helm charts
+Create a namespace for the APISIX Ingress
+```shell
+kubectl create ns ingress-apisix
+```
+
+Install APISIX Ingress
+```shell
+helm install apisix apisix/apisix \
+  --set gateway.type=NodePort \
+  --set ingress-controller.enabled=true \
+  --namespace ingress-apisix \
+  --set ingress-controller.config.apisix.serviceNamespace=ingress-apisix
+```
+
+Verify the service is created
+```shell
+kubectl get service --namespace ingress-apisix
+```
+
+Patch the nodeport for the service
+Kubernetes by default assigns a nodeport in the range of 30000-32767
+
+Since we made a kind `extraPortMapping` rule forwarding port `80` to `30965` we need to make sure the nodeport for the APISIX gateway is set to `30965`
+
+```shell
+kubectl patch svc apisix-gateway -n ingress-apisix --type='json' -p '[{"op":"replace","path":"/spec/type","value":"NodePort"},{"op":"replace","path":"/spec/ports/0/nodePort","value":30965}]'
+```
+
+### Install Upstream API's
+Installs two upstream (backend) API's `Foo` and `Bar`
+```shell
+kubectl apply -f upstream-apis.yaml
+```
+
+### Apply the APISIX ingress routing rules
+The APISIX routing rules are path based `/foo/*` will route to the `foo` service. `/bar/*` will route to the `bar` service.
+
+```shell
+kubectl apply -f http-route.yaml
+```
+
+### Verify the APISIX routes
+Invoke the foo service via APISIX
+```shell
+curl -v localhost/hostname -H 'Host: foo.org'
+```
+If everything is setup correctly the output should be:
+foo-app
+
+Invoke the bar service via APISIX
+```shell
+curl -v localhost/hostname -H 'Host: bar.org'
+```
+If everything is setup correctly the output should be:
+bar-app

--- a/deployment/kind-ingress/http-route.yaml
+++ b/deployment/kind-ingress/http-route.yaml
@@ -1,0 +1,25 @@
+# httpbin-route.yaml
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: httpserver-route
+spec:
+  http:
+  - name: fooRule
+    match:
+      hosts:
+        - foo.org
+      paths:
+      - /*
+    backends:
+       - serviceName: foo-service
+         servicePort: 8080
+  - name: barRule
+    match: 
+      hosts:
+        - bar.org
+      paths: 
+      - /*
+    backends: 
+      - serviceName: bar-service
+        servicePort: 8080

--- a/deployment/kind-ingress/kind-cluster-config.yaml
+++ b/deployment/kind-ingress/kind-cluster-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  # port forward 80 on the host to 30965 on this node
+  extraPortMappings:
+  - containerPort: 30965
+    hostPort: 80

--- a/deployment/kind-ingress/upstream-apis.yaml
+++ b/deployment/kind-ingress/upstream-apis.yaml
@@ -1,0 +1,53 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: foo-app
+  labels:
+    app: foo
+spec:
+  containers:
+  - command:
+    - /agnhost
+    - netexec
+    - --http-port
+    - "8080"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
+    name: foo-app
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: foo-service
+spec:
+  selector:
+    app: foo
+  ports:
+  # Default port used by the image
+  - port: 8080
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: bar-app
+  labels:
+    app: bar
+spec:
+  containers:
+  - command:
+    - /agnhost
+    - netexec
+    - --http-port
+    - "8080"
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
+    name: bar-app
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: bar-service
+spec:
+  selector:
+    app: bar
+  ports:
+  # Default port used by the image
+  - port: 8080


### PR DESCRIPTION
Instructions and manifest files for:

- Setup a local kubernetes cluster using kind
- install APISIX as Kubernetes Ingress
- deploy two backend API's
- Create a APISIX route to proxy the two backend API's based on host based routing