### PR TITLE
Minify Makefile and allow access to admin API from all IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-.PHONY: build-gateway
-dev-build:
-	docker build --build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') -t frank-api-gateway .
-
-.PHONY: build-dashboard
-dashboard-build:
-	docker build -f dashboard/Dockerfile --build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') -t frank-api-dashboard .

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,7 @@
-
-
-.PHONY: dev-build
+.PHONY: build-gateway
 dev-build:
 	docker build --build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') -t frank-api-gateway .
 
-# Uses the frank-api-gateway build with the local config files to run the gateway in standalone mode
-.PHONY: gw-startup
-gw-startup:
-	docker run -d --name frank-api-gateway-standalone \
-  	-p 9080:9080 \
-  	-p 9443:9443 \
-  	-p 9090:9090 \
-	-v $(shell pwd)/conf/config.yaml:/usr/local/apisix/conf/config.yaml \
-	-v $(shell pwd)/conf/apisix.yaml:/usr/local/apisix/conf/apisix.yaml \
-	--add-host=host.docker.internal:host-gateway \
-	--add-host=manager.organization-a.nlx.local:host-gateway \
-	--add-host=controller-api.organization-a.nlx.local:host-gateway \
-	--add-host=txlog-api.organization-a.nlx.local:host-gateway \
-  	frank-api-gateway:latest
-
-.PHONY: gw-rm
-gw-rm:
-	docker rm frank-api-gateway-standalone
-
-.PHONY: gw-start
-gw-start:
-	docker start frank-api-gateway-standalone
-
-.PHONY: gw-stop
-gw-stop:
-	docker stop frank-api-gateway-standalone
-
-.PHONY: gw-reload
-gw-reload:
-	docker exec -it frank-api-gateway-standalone apisix reload
-
-.PHONY: gw-shell
-gw-shell:
-	docker exec -it frank-api-gateway-standalone /bin/bash
-
-.PHONY: gw-image-rm
-gw-image-rm:
-	docker rmi frank-api-gateway
-
-.PHONY: gw-logs
-gw-logs:
-	docker logs --follow frank-api-gateway-standalone
-
-.PHONY: dashboard-build
+.PHONY: build-dashboard
 dashboard-build:
 	docker build -f dashboard/Dockerfile --build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') -t frank-api-dashboard .

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ This repository contains two components:
 1) deployment configurations & examples which can be found on the directory `deployment-examples`
 2) source code for custom plugins
 
+### Building the images
+The Frank!Gateway can be built using the following command:
+```shell
+docker build --build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') -t frank-api-gateway .
+```
+
+The accompanying dashboard can be built with the following command:
+```shell
+docker build -f dashboard/Dockerfile --build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') -t frank-api-dashboard .
+``` 
+
 ### Deployment configurations & examples
 The directory `deployment-examples` contains four deployment scenarios for deploying APISIX. Note, this deploys vanilla APISIX without the FSC plugin.
 The goal of these deployment examples is for experimenting with Apache APISIX in different deployment approaches.

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -653,8 +653,8 @@ deployment:                    # Deployment configurations
         role: viewer
 
     enable_admin_cors: true       # Enable Admin API CORS response header `Access-Control-Allow-Origin`.
-    allow_admin:                  # Limit Admin API access by IP addresses.
-      - 127.0.0.0/24              # If not set, any IP address is allowed.
+    # allow_admin:                  # Limit Admin API access by IP addresses.
+      # - 127.0.0.0/24              # If not set, any IP address is allowed.
       # - "::/64"
     admin_listen:                 # Set the Admin API listening addresses.
       ip: 0.0.0.0                 # Set listening IP.


### PR DESCRIPTION
I've cleaned up the Makefile to only include commands, which build the Frank!Gateway. This is to reduce the confusion of possible aliases.

The `allow_admin` config key is commented, because (on Windows) you cannot access the admin API with the current setting. Removing the config key allows requests from all IPs.