### PR TITLE
ci: change image tag to run_id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: version-next
+  #  needs: version-next
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,27 +19,27 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  version-next:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      version-next: ${{ steps.reference.outputs.next-reference }}
-      version-next-strict: ${{ steps.reference.outputs.next-reference }}
-    steps:
-      - uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            github.com:443
+  # version-next:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #   outputs:
+  #     version-next: ${{ steps.reference.outputs.next-reference }}
+  #     version-next-strict: ${{ steps.reference.outputs.next-reference }}
+  #   steps:
+  #     - uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+  #       with:
+  #         disable-sudo: true
+  #         egress-policy: block
+  #         allowed-endpoints: >
+  #           github.com:443
 
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #4.1.7
+  #     - name: Checkout
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #4.1.7
 
-      - name: Next Reference
-        id: reference
-        uses: wearefrank/ci-cd-templates/next-reference@5ec30763e8d8eeed008edcac3c6a329367e42760 #1.0.4
+  #     - name: Next Reference
+  #       id: reference
+  #       uses: wearefrank/ci-cd-templates/next-reference@5ec30763e8d8eeed008edcac3c6a329367e42760 #1.0.4
  
           
   build-and-push-image:
@@ -88,14 +88,14 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #5.5.1
         with:
           images: ${{ matrix.image }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.version-next.outputs.version-next }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version-next.outputs.version-next }}
-            type=semver,pattern={{major}},value=${{ needs.version-next.outputs.version-next }}
-            type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-          flavor: |
-            latest=false
+          tags: ${{ github.run_id }}
+          #   type=semver,pattern={{version}},value=${{ needs.version-next.outputs.version-next }}
+          #   type=semver,pattern={{major}}.{{minor}},value=${{ needs.version-next.outputs.version-next }}
+          #   type=semver,pattern={{major}},value=${{ needs.version-next.outputs.version-next }}
+          #   type=ref,event=pr
+          #   type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          # flavor: |
+          #   latest=false
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,54 +18,52 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    outputs:
-      version-next: ${{ steps.next-version.outputs.release-version }}
-      version-next-tag: ${{ steps.next-version.outputs.release-tag }}
-      version-next-type: ${{ steps.next-version.outputs.release-type }}
-    steps:
-      - uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          egress-policy: audit
+  # release:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     version-next: ${{ steps.next-version.outputs.release-version }}
+  #     version-next-tag: ${{ steps.next-version.outputs.release-tag }}
+  #     version-next-type: ${{ steps.next-version.outputs.release-type }}
+  #   steps:
+  #     - uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+  #       with:
+  #         egress-policy: audit
 
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #4.1.7
-        with:
-          token: ${{ secrets.WEAREFRANK_BOT_PAT }}
+  #     - name: Checkout
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #4.1.7
+  #       with:
+  #         token: ${{ secrets.WEAREFRANK_BOT_PAT }}
 
-      - name: Download Pre-build Artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
-        with:
-          pattern: pre-build-*
-          merge-multiple: true
+  #     - name: Download Pre-build Artifacts
+  #       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
+  #       with:
+  #         pattern: pre-build-*
+  #         merge-multiple: true
 
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
-        with:
-          pattern: build-*
-          merge-multiple: true
+  #     - name: Download Build Artifacts
+  #       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #4.1.8
+  #       with:
+  #         pattern: build-*
+  #         merge-multiple: true
 
-      - name: Setup Node
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #4.0.3
-        with:
-          node-version: 20
+  #     - name: Setup Node
+  #       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b #4.0.3
+  #       with:
+  #         node-version: 20
 
-      - name: Install dependencies
-        run: yarn global add semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/exec @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
+  #     - name: Install dependencies
+  #       run: yarn global add semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/exec @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
 
-      - name: Semantic Release
-        id: next-version
-        run: semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.WEAREFRANK_BOT_PAT }}
-          GH_TOKEN: ${{ secrets.WEAREFRANK_BOT_PAT }}
-
- 
+  #     - name: Semantic Release
+  #       id: next-version
+  #       run: semantic-release
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.WEAREFRANK_BOT_PAT }}
+  #         GH_TOKEN: ${{ secrets.WEAREFRANK_BOT_PAT }}
           
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: release
+  #  needs: release
     strategy:
       fail-fast: false
       matrix:
@@ -109,14 +107,14 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #5.5.1
         with:
           images: ${{ matrix.image }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.release.outputs.version-next }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.version-next }}
-            type=semver,pattern={{major}},value=${{ needs.release.outputs.version-next }}
-            type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-          flavor: |
-            latest=false
+          tags: ${{github.run_id}}
+          #   type=semver,pattern={{version}},value=${{ needs.release.outputs.version-next }}
+          #   type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.version-next }}
+          #   type=semver,pattern={{major}},value=${{ needs.release.outputs.version-next }}
+          #   type=ref,event=pr
+          #   type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          # flavor: |
+          #   latest=false
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Changed ci and release workflows to use run_id as image tag since repo is still private.