### PR TITLE
Jwt client ssl fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ LABEL org.opencontainers.image.version="0.2-beta"
 
 ARG BUILD_DATE
 LABEL org.opencontainers.image.created=$BUILD_DATE
-LABEL org.opencontainers.image.authors="https://github.com/pimg, https://github.com/jjansenvr"
 LABEL based-on="Apache APISIX 3.8"
 
 COPY src /usr/local/apisix/custom-plugins

--- a/src/apisix/plugins/jwt-client.lua
+++ b/src/apisix/plugins/jwt-client.lua
@@ -84,6 +84,7 @@ function _M.access(conf, ctx)
 		scheme = parsed_url.scheme,
 		host = parsed_url.host,
 		port = parsed_url.port,
+		ssl_server_name = parsed_url.host
 	})
 	core.log.info("JWT client after connect", err)
 
@@ -103,7 +104,7 @@ function _M.access(conf, ctx)
 			path = parsed_url.path,
 			body = request_body,
 			headers = {
-				["Content-Type"] = "application/json",
+				["Content-Type"] = "application/json"
 			},
 		})
 		core.log.info("JWT client request")


### PR DESCRIPTION
Added a parameter to the http:connect function that sets the server name as a header when connecting for SSL connections