### PR TITLE
Add response extractor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following plugins have been created:
 2) SOAP action router
 3) OIDC client
 4) Limit size
+5) Response extractor
 
 ### FSC 
 The FSC plugin:
@@ -85,3 +86,22 @@ Detailed documentation on the Generic OAuth Client plugin can be found here [her
 
 ### Limit size
 blocks either requests and or responses if the payload or entire request or response is larger than a pre-configured threshold.
+
+### Response extractor
+Extracts values from upstream JSON response bodies using [JSONPath](https://goessner.net/articles/JsonPath/) expressions and exposes them as APISIX request context variables for use by downstream plugins or log formats.
+
+The plugin is configured as a map of variable name → JSONPath expression. Each matched value is:
+- Stored in `ctx.extracted` (a Lua table, accessible by other plugins in the same request)
+- Stored as `ctx.var.extracted` (a JSON-encoded string, usable in `log_format`)
+- Stored individually as `ctx.var.<variable_name>` for direct access in log formats or other plugins
+
+Example configuration:
+```yaml
+response-extractor:
+  transaction_id: "$.transactionId"
+  status_code: "$.result.status"
+```
+
+This would make `$transaction_id` and `$status_code` available as APISIX variables for logging or further processing.
+
+> **Note:** The plugin only processes JSON responses (`application/json` or `+json`). Responses without a JSON body are silently skipped. The extractor buffers up to 1 MB of response body; larger responses are skipped to protect memory usage.

--- a/src/apisix/plugins/response-extractor.lua
+++ b/src/apisix/plugins/response-extractor.lua
@@ -1,0 +1,153 @@
+local core = require("apisix.core")
+local jsonpath = require("jsonpath")
+
+local ngx = ngx
+local plugin_name = "response-extractor"
+local max_response_body_bytes = 1024 * 1024
+
+local _M = {
+    version = 1,
+    priority = 1000,
+    name = plugin_name,
+    schema = {
+        type = "object",
+        patternProperties = {
+            ["^[a-zA-Z_][a-zA-Z0-9_]*$"] = {
+                type = "string",
+                description = "JSONPath expression"
+            }
+        },
+        additionalProperties = false
+    }
+}
+
+function _M.check_schema(conf)
+    return core.schema.check(_M.schema, conf)
+end
+
+local function safe_json_decode(body)
+    local data, err = core.json.decode(body)
+    if not data then
+        core.log.warn("failed to decode response body: ", err)
+        return nil
+    end
+    return data
+end
+
+local function extract_all(conf, data)
+    local results = {}
+
+    for var_name, path in pairs(conf) do
+        local res, err = jsonpath.query(data, path)
+        if not res then
+            core.log.warn("jsonpath error for ", var_name, ": ", err)
+        else
+            results[var_name] = res[1]
+        end
+    end
+
+    return results
+end
+
+local function to_var_string(value)
+    local value_type = type(value)
+
+    if value_type == "string" then
+        return value
+    end
+
+    if value_type == "number" or value_type == "boolean" then
+        return tostring(value)
+    end
+
+    if value == nil then
+        return nil
+    end
+
+    return core.json.encode(value)
+end
+
+local function is_json_response()
+    local headers = ngx.resp.get_headers()
+    if not headers then
+        return false
+    end
+
+    local content_type = headers["Content-Type"] or headers["content-type"]
+    if not content_type then
+        return false
+    end
+
+    content_type = string.lower(content_type)
+    return string.find(content_type, "application/json", 1, true)
+        or string.find(content_type, "+json", 1, true)
+end
+
+function _M.body_filter(conf, ctx)
+    local chunk = ngx.arg[1]
+    local eof = ngx.arg[2]
+
+    if ctx._skip_response_extractor then
+        return
+    end
+
+    if ctx._response_extractor_checked_content_type == nil then
+        ctx._response_extractor_checked_content_type = true
+        if not is_json_response() then
+            core.log.warn("skipping response extraction: not a JSON response")
+            ctx._skip_response_extractor = true
+            return
+        end
+    end
+
+    ctx._resp_body_chunks = ctx._resp_body_chunks or {}
+    ctx._resp_body_size = ctx._resp_body_size or 0
+
+    if chunk and #chunk > 0 then
+        ctx._resp_body_size = ctx._resp_body_size + #chunk
+        if ctx._resp_body_size > max_response_body_bytes then
+            core.log.warn("skipping response extraction: response body too large")
+            ctx._skip_response_extractor = true
+            ctx._resp_body_chunks = nil
+            ctx._resp_body_size = nil
+            return
+        end
+
+        table.insert(ctx._resp_body_chunks, chunk)
+    end
+
+    if not eof then
+        return
+    end
+
+    local body = table.concat(ctx._resp_body_chunks)
+    ctx._resp_body_chunks = nil
+    ctx._resp_body_size = nil
+
+    if body == "" then
+        return
+    end
+
+    local data = safe_json_decode(body)
+    if not data then
+        return
+    end
+
+    local results = extract_all(conf, data)
+
+    -- store per-request (usable by other plugins)
+    ctx.extracted = results
+
+    -- expose individually to log_format
+    ctx.var.extracted = core.json.encode(results)
+
+    -- Expose flattened variables for direct use.
+    for k, v in pairs(results) do
+        local var_value = to_var_string(v)
+        if var_value ~= nil then
+            ctx.var[k] = var_value
+        end
+    end
+end
+
+return _M


### PR DESCRIPTION

This pull request introduces a new plugin called `response-extractor` for APISIX, along with documentation updates. The `response-extractor` plugin allows users to extract values from upstream JSON response bodies using JSONPath expressions and exposes those values as request context variables for use by downstream plugins or log formats. The documentation has also been updated to describe the plugin and its configuration.

**New plugin: Response Extractor**

* Added a new plugin `response-extractor` in `src/apisix/plugins/response-extractor.lua` that extracts values from JSON responses using JSONPath, exposes them as APISIX variables, and stores them for use by other plugins or in log formats. The plugin only processes responses with a JSON content type and skips large or non-JSON responses.

**Documentation updates**

* Added `Response extractor` to the list of available plugins in the `README.md` file.
* Added detailed documentation for the new `response-extractor` plugin, including usage, configuration examples, and notes on behavior and limitations, to the `README.md`.