### PR TITLE
Add build context and OPA plugin patch for APISIX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ ARG BUILD_DATE
 LABEL org.opencontainers.image.created=$BUILD_DATE
 LABEL based-on="Apache APISIX 3.14.1 Ubuntu"
 
+# Overlay patched APISIX plugins from the local patches folder.
+# Files with the same path/name in /usr/local/apisix/apisix/plugins are replaced.
+COPY patches/ /usr/local/apisix/apisix/plugins/
+
 COPY src /usr/local/apisix/custom-plugins
 COPY conf/config.yaml /usr/local/apisix/conf/config.yaml
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@
 name: frank-gateway # Name of the parent container
 services:
   apisix:
+    build:
+      context: .
     image: ghcr.io/wearefrank/frank-gateway:master
     restart: always
     volumes:

--- a/patches/opa.lua
+++ b/patches/opa.lua
@@ -1,0 +1,153 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local core   = require("apisix.core")
+local http   = require("resty.http")
+local helper = require("apisix.plugins.opa.helper")
+local type   = type
+local ipairs = ipairs
+
+local schema = {
+    type = "object",
+    properties = {
+        host = {type = "string"},
+        ssl_verify = {
+            type = "boolean",
+            default = true,
+        },
+        policy = {type = "string"},
+        timeout = {
+            type = "integer",
+            minimum = 1,
+            maximum = 60000,
+            default = 3000,
+            description = "timeout in milliseconds",
+        },
+        keepalive = {type = "boolean", default = true},
+        send_headers_upstream = {
+            type = "array",
+            minItems = 1,
+            items = {
+                type = "string"
+            },
+            description = "list of headers to pass to upstream in request"
+        },
+        keepalive_timeout = {type = "integer", minimum = 1000, default = 60000},
+        keepalive_pool = {type = "integer", minimum = 1, default = 5},
+        with_route = {type = "boolean", default = false},
+        with_service = {type = "boolean", default = false},
+        with_consumer = {type = "boolean", default = false},
+        with_body = {type = "boolean", default = false}
+    },
+    required = {"host", "policy"}
+}
+
+
+local _M = {
+    version = 0.1,
+    priority = 2001,
+    name = "opa",
+    schema = schema,
+}
+
+
+function _M.check_schema(conf)
+    local check = {"host"}
+    core.utils.check_https(check, conf, _M.name)
+    core.utils.check_tls_bool({"ssl_verify"}, conf, _M.name)
+    return core.schema.check(schema, conf)
+end
+
+
+function _M.access(conf, ctx)
+    local body = helper.build_opa_input(conf, ctx, "http")
+
+    local params = {
+        method = "POST",
+        body = core.json.encode(body),
+        headers = {
+            ["Content-Type"] = "application/json",
+        },
+        keepalive = conf.keepalive,
+        ssl_verify = conf.ssl_verify
+    }
+
+    if conf.keepalive then
+        params.keepalive_timeout = conf.keepalive_timeout
+        params.keepalive_pool = conf.keepalive_pool
+    end
+
+    local endpoint = conf.host .. "/v1/data/" .. conf.policy
+
+    local httpc = http.new()
+    httpc:set_timeout(conf.timeout)
+
+    local res, err = httpc:request_uri(endpoint, params)
+
+    -- block by default when decision is unavailable
+    if not res then
+        core.log.error("failed to process OPA decision, err: ", err)
+        return 403
+    end
+
+    -- parse the results of the decision
+    local data, err = core.json.decode(res.body)
+
+    if not data then
+        core.log.error("invalid response body: ", res.body, " err: ", err)
+        return 503
+    end
+
+    if not data.result then
+        core.log.error("invalid OPA decision format: ", res.body,
+                       " err: `result` field does not exist")
+        return 503
+    end
+
+    local result = data.result
+
+    if not result.allow then
+        if result.headers then
+            core.response.set_header(result.headers)
+        end
+
+        local status_code = 403
+        if result.status_code then
+            status_code = result.status_code
+        end
+
+        local reason = nil
+        if result.reason then
+            reason = type(result.reason) == "table"
+                and core.json.encode(result.reason)
+                or result.reason
+        end
+
+        return status_code, reason
+    else if result.headers and conf.send_headers_upstream then
+        for _, name in ipairs(conf.send_headers_upstream) do
+            local value = result.headers[name]
+            if value then
+                core.request.set_header(ctx, name, value)
+            end
+        end
+        end
+    end
+end
+
+
+return _M

--- a/patches/opa/helper.lua
+++ b/patches/opa/helper.lua
@@ -1,0 +1,143 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local core        = require("apisix.core")
+local get_service = require("apisix.http.service").get
+local ngx_time    = ngx.time
+
+local _M = {}
+
+
+-- build a table of Nginx variables with some generality
+-- between http subsystem and stream subsystem
+local function build_var(conf, ctx)
+    return {
+        server_addr = ctx.var.server_addr,
+        server_port = ctx.var.server_port,
+        remote_addr = ctx.var.remote_addr,
+        remote_port = ctx.var.remote_port,
+        timestamp   = ngx_time(),
+    }
+end
+
+local function get_body_for_request()
+    local original_body, err = core.request.get_body()
+    if err then
+        return nil, "failed to get request body: " .. err
+    end
+    if original_body == nil then
+        return nil
+    end
+    -- decode to prevent double encoded json objects
+    local body, err = core.json.decode(original_body)
+    if err then
+        -- if its not json, the body can just be added
+        body = original_body
+    end
+    return body
+end
+
+local function build_http_request(conf, ctx)
+    local http = {
+        scheme  = core.request.get_scheme(ctx),
+        method  = core.request.get_method(),
+        host    = core.request.get_host(ctx),
+        port    = core.request.get_port(ctx),
+        path    = ctx.var.uri,
+        headers = core.request.headers(ctx),
+        query   = core.request.get_uri_args(ctx),
+    }
+
+    if conf.with_body then
+        local body, err = get_body_for_request()
+        if err then
+            core.log.error(err)
+        else
+            http.body = body
+        end
+    end
+
+    return http
+end
+
+local function build_http_route(conf, ctx, remove_upstream)
+    local route = core.table.deepcopy(ctx.matched_route).value
+
+    if remove_upstream and route and route.upstream then
+        -- unimportant to send upstream info to OPA
+        route.upstream = nil
+    end
+
+    return route
+end
+
+
+local function build_http_service(conf, ctx)
+    local service_id = ctx.service_id
+
+    -- possible that there is no service bound to the route
+    if service_id then
+        local service = core.table.clone(get_service(service_id)).value
+
+        if service then
+            if service.upstream then
+                service.upstream = nil
+            end
+            return service
+        end
+    end
+
+    return nil
+end
+
+
+local function build_http_consumer(conf, ctx)
+    -- possible that there is no consumer bound to the route
+    if ctx.consumer then
+        return core.table.clone(ctx.consumer)
+    end
+
+    return nil
+end
+
+
+function _M.build_opa_input(conf, ctx, subsystem)
+    local data = {
+        type    = subsystem,
+        request = build_http_request(conf, ctx),
+        var     = build_var(conf, ctx)
+    }
+
+    if conf.with_route then
+        data.route = build_http_route(conf, ctx, true)
+    end
+
+    if conf.with_consumer then
+        data.consumer = build_http_consumer(conf, ctx)
+    end
+
+    if conf.with_service then
+        data.service = build_http_service(conf, ctx)
+    end
+
+    return {
+        input = data,
+    }
+end
+
+
+return _M


### PR DESCRIPTION
This pull request introduces support for overlaying custom patched APISIX plugins, specifically adding a patched Open Policy Agent (OPA) plugin and its helper module. It also updates the Docker and Compose configuration to ensure these patches are included in the build.

**Plugin patching and integration:**

* Added a mechanism in the `Dockerfile` to overlay patched APISIX plugins from the local `patches/` directory, allowing custom or modified plugins to replace the defaults in `/usr/local/apisix/apisix/plugins/`.
* Added a patched OPA plugin implementation in `/patches`, to add the with_body feature to send the request body to the opa client.
code from:
https://github.com/apache/apisix/pull/11629

**Build and deployment configuration:**

* Updated `docker-compose.yaml` to use a build context, ensuring that the local `patches/` directory is included during the image build process.