### PR TITLE
Implemented support for APISIX OPA authorization with request body forwarding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following plugins have been created:
 7) Cert Auth
 8) Frank sender 
 9) JWT client
+10) OPA
 
 
 ## Testing
@@ -141,3 +142,11 @@ APISIX has existing authentication plugins for validating incoming tokens, but t
 The JWT Client plugin enables the Frank!Gateway to request a JWT access token from an external IDP, cache it, and add it as a Bearer token on upstream requests.
 
 Example configuration and tests for the JWT Client plugin can be found [here](tests/jwt-client/apisix.yaml) and [here](tests/bruno/jwt-client).
+
+### OPA
+
+This project uses the APISIX OPA plugin for authorization decisions via Open Policy Agent.
+The only project-specific customization is support for the `with_body` attribute, so request bodies can be forwarded to OPA input.
+All other OPA plugin behavior follows standard APISIX logic.
+
+An example local test setup for the `with_body` behavior is available in [tests/opa](tests/opa), with a sample Rego policy in [tests/opa/policies/example-authz.rego](tests/opa/policies/example-authz.rego).

--- a/run-all-tests.bat
+++ b/run-all-tests.bat
@@ -57,6 +57,7 @@ call :run_suite generic-oauth
 call :run_suite jwt-client
 call :run_suite limit-size
 call :run_suite oidc-client
+call :run_suite opa
 call :run_suite soap-action-router
 
 echo.

--- a/tests/bruno/opa/01-allow-header-200.bru
+++ b/tests/bruno/opa/01-allow-header-200.bru
@@ -1,0 +1,41 @@
+meta {
+  name: body allow true returns 200
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/any/opa-auth
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "allow": true,
+    "subject": "body-user"
+  }
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("upstream receives x-opa-user header", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("headers");
+
+    const headers = body.headers;
+    const key = Object.keys(headers).find(function(k) {
+      return k.toLowerCase() === "x-opa-user";
+    });
+
+    expect(key).to.not.equal(undefined);
+    expect(String(headers[key])).to.equal("body-user");
+  });
+}

--- a/tests/bruno/opa/02-missing-header-403.bru
+++ b/tests/bruno/opa/02-missing-header-403.bru
@@ -1,0 +1,27 @@
+meta {
+  name: body allow false returns 403
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/any/opa-auth
+  body: json
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "allow": false,
+    "subject": "body-user"
+  }
+}
+
+tests {
+  test("status is 403", function() {
+    expect(res.getStatus()).to.equal(403);
+  });
+}

--- a/tests/bruno/opa/bruno.json
+++ b/tests/bruno/opa/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "name": "opa",
+  "type": "collection"
+}

--- a/tests/bruno/opa/environments/docker.bru
+++ b/tests/bruno/opa/environments/docker.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://host.docker.internal:9080
+}

--- a/tests/opa/apisix.yaml
+++ b/tests/opa/apisix.yaml
@@ -1,0 +1,26 @@
+routes:
+  - name: opa-auth-check
+    uri: /any/opa-auth
+    service_id: 1
+
+services:
+  - id: 1
+    name: opa-auth-service
+    upstream_id: 1
+    plugins:
+      opa:
+        host: http://opa:8181
+        policy: apisix/authz/result
+        with_body: true
+        with_route: true
+        send_headers_upstream:
+          - x-opa-user
+
+upstreams:
+  - id: 1
+    name: echo-upstream
+    desc: echo API
+    type: roundrobin
+    nodes:
+      "httpbun:80": 1
+#END

--- a/tests/opa/docker-compose.yaml
+++ b/tests/opa/docker-compose.yaml
@@ -1,0 +1,39 @@
+name: frank-gateway-opa-test
+services:
+  apisix:
+    image: ghcr.io/wearefrank/frank-gateway:master
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+    restart: always
+    volumes:
+      - ../../src:/usr/local/apisix/custom-plugins
+      - ./apisix.yaml:/usr/local/apisix/conf/apisix.yaml
+      - ../../conf/config.yaml:/usr/local/apisix/conf/config.yaml
+    ports:
+      - "9080:9080/tcp"
+      - "9443:9443/tcp"
+    networks:
+      apisix:
+
+  httpbun:
+    image: sharat87/httpbun:fd75552c42e61cf61e578e4459da372754596f08
+    restart: always
+    networks:
+      apisix:
+
+  opa:
+    image: openpolicyagent/opa:0.70.0
+    command:
+      - "run"
+      - "--server"
+      - "--addr=0.0.0.0:8181"
+      - "/policies"
+    volumes:
+      - ./policies:/policies:ro
+    networks:
+      apisix:
+
+networks:
+  apisix:
+    driver: bridge

--- a/tests/opa/policies/example-authz.rego
+++ b/tests/opa/policies/example-authz.rego
@@ -1,0 +1,21 @@
+package apisix.authz
+
+# Example OPA policy document consumed by APISIX at /v1/data/apisix/authz/result
+# Allow only when request body includes {"allow": true}.
+default result := {
+  "allow": false,
+  "status_code": 403,
+  "reason": "access denied: request body must include allow=true"
+}
+
+result := {
+  "allow": true,
+  "headers": {
+    "x-opa-user": subject
+  }
+} {
+  body := object.get(input.request, "body", {})
+  is_object(body)
+  body.allow == true
+  subject := object.get(body, "subject", "demo-user")
+}


### PR DESCRIPTION
Changes

- Added a patched OPA plugin overlay in the Docker image build
- Extended the APISIX OPA plugin with with_body support to include request bodies in OPA input
- Added local OPA test setup with sample Rego policy and Bruno tests
- Updated Docker Compose to build from the local Dockerfile so patched plugins are included
- Documented OPA support and test usage in the README
- Added OPA test suite to the automated test runner

Notes

- The customization is intentionally minimal and preserves standard APISIX OPA plugin behavior outside of with_body
- Example policy demonstrates authorization decisions and upstream header injection based on request body content